### PR TITLE
(BKR-1270) Use fog-openstack instead of fog

### DIFF
--- a/beaker-openstack.gemspec
+++ b/beaker-openstack.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
-  s.add_runtime_dependency 'fog', '~> 1.38'
+  s.add_runtime_dependency 'fog-openstack', '>= 0'
 
 end
 

--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -23,7 +23,7 @@ module Beaker
     #@option options [String] :project Added as metadata to each OpenStack instance
     #@option options [Integer] :timeout The amount of time to attempt execution before quiting and exiting with failure
     def initialize(openstack_hosts, options)
-      require 'fog'
+      require 'fog/openstack'
       @options = options
       @logger = options[:logger]
       @hosts = openstack_hosts

--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'fog'
+require 'fog/openstack'
 
 module Beaker
   describe Openstack do


### PR DESCRIPTION
This commit swaps `fog-openstack` for `fog` as the runtime dependency of the
beaker-openstack project. The top-level `fog` gem drags in all of the fog
hypervisors, 31 of which are not OpenStack. This swap trims the dependency
tree down to just what beaker-openstack actually needs.