### PR TITLE
hypervisor/openstack: fix usage with V3 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ doc
 .vagrant/
 .vagrant_files/
 sut-files.tgz
+vendor/

--- a/beaker-openstack.gemspec
+++ b/beaker-openstack.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
-  s.add_runtime_dependency 'fog-openstack', '~> 0.3.10'
+  s.add_runtime_dependency 'fog-openstack', '~> 1.0.0'
 
 end
 

--- a/beaker-openstack.gemspec
+++ b/beaker-openstack.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
-  s.add_runtime_dependency 'fog-openstack', '>= 1.0.8'
+  s.add_runtime_dependency 'fog-openstack', '>= 0'
 
 end
 

--- a/beaker-openstack.gemspec
+++ b/beaker-openstack.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
-  s.add_runtime_dependency 'fog-openstack', '>= 0'
+  s.add_runtime_dependency 'fog-openstack', '~> 0.3.10'
 
 end
 

--- a/beaker-openstack.gemspec
+++ b/beaker-openstack.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
-  s.add_runtime_dependency 'fog-openstack', '>= 0'
+  s.add_runtime_dependency 'fog-openstack', '>= 1.0.8'
 
 end
 

--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -207,7 +207,7 @@ module Beaker
       begin
         @logger.debug "Creating IP"
         ip = @compute_client.addresses.create
-      rescue Fog::OpenStack::Compute::NotFound
+      rescue Fog::Compute::OpenStack::NotFound
         # If there are no more floating IP addresses, allocate a
         # new one and try again.
         @compute_client.allocate_address(@options[:floating_ip_pool])

--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -67,13 +67,13 @@ module Beaker
       @compute_client ||= Fog::Compute.new(@credentials)
 
       if not @compute_client
-        raise "Unable to create OpenStack Compute instance (api key: #{@options[:openstack_api_key]}, username: #{@options[:openstack_username]}, auth_url: #{@options[:openstack_auth_url]}, tenant: #{@options[:openstack_tenant]})"
+        raise "Unable to create OpenStack Compute instance (api key: #{@options[:openstack_api_key]}, username: #{@options[:openstack_username]}, auth_url: #{@options[:openstack_auth_url]}, tenant: #{@options[:openstack_tenant]}, project_name: #{@options[:openstack_project_name]})"
       end
 
       @network_client ||= Fog::Network.new(@credentials)
 
       if not @network_client
-        raise "Unable to create OpenStack Network instance (api_key: #{@options[:openstack_api_key]}, username: #{@options[:openstack_username]}, auth_url: #{@options[:openstack_auth_url]}, tenant: #{@options[:openstack_tenant]})"
+        raise "Unable to create OpenStack Network instance (api key: #{@options[:openstack_api_key]}, username: #{@options[:openstack_username]}, auth_url: #{@options[:openstack_auth_url]}, tenant: #{@options[:openstack_tenant]}, project_name: #{@options[:openstack_project_name]})"
       end
 
       # Validate openstack_volume_support setting value, reset to boolean if passed via ENV value string

--- a/lib/beaker/hypervisor/openstack.rb
+++ b/lib/beaker/hypervisor/openstack.rb
@@ -207,7 +207,7 @@ module Beaker
       begin
         @logger.debug "Creating IP"
         ip = @compute_client.addresses.create
-      rescue Fog::Compute::OpenStack::NotFound
+      rescue Fog::OpenStack::Compute::NotFound
         # If there are no more floating IP addresses, allocate a
         # new one and try again.
         @compute_client.allocate_address(@options[:floating_ip_pool])

--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -52,6 +52,7 @@ module Beaker
         expect(credentials[:openstack_user_domain]).to eq('acme.com')
         expect(credentials[:openstack_project_domain]).to eq('R&D')
         expect(credentials[:openstack_project_name]).to eq('Team_test_abc')
+        expect(credentials[:openstack_tenant]).to be_nil
       end
     end
 

--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -4,7 +4,7 @@ require 'fog/openstack'
 module Beaker
   describe Openstack do
 
-    let(:options) { make_opts.merge({'logger' => double().as_null_object}) }
+    let(:options) { make_opts.merge({'logger' => double().as_null_object, 'openstack_floating_ip' => true}) }
 
     let(:openstack) {
       Openstack.new(@hosts, options)
@@ -110,7 +110,7 @@ module Beaker
         # Simulate getting a dynamic IP from OpenStack to test key generation code
         # after provisioning. See _validate_new_key_pair in openstack/nova for reference
         mock_ip = double().as_null_object
-        allow( openstack ).to receive( :get_ip ).and_return( mock_ip )
+        allow( openstack ).to receive( :get_floating_ip ).and_return( mock_ip )
         allow( mock_ip ).to receive( :ip ).and_return( '172.16.0.1' )
         openstack.instance_eval('@options')['openstack_keyname'] = nil
 
@@ -125,7 +125,7 @@ module Beaker
         end
       end
 
-      it 'get_ip always allocates a new floatingip' do
+      it 'get_floating_ip always allocates a new floatingip' do
         # Assume beaker is being executed in parallel N times by travis (or similar).
         # IPs are allocated (but not associated) before an instance is created; it is
         # hightly possible the first instance will allocate a new IP and create an ssh
@@ -138,7 +138,7 @@ module Beaker
         allow(@compute_client).to receive(:addresses).and_return(mock_addresses)
         allow(mock_addresses).to receive(:create).and_return(mock_ip)
         expect(mock_addresses).to receive(:create).exactly(3).times
-        (1..3).each { openstack.get_ip }
+        (1..3).each { openstack.get_floating_ip }
       end
 
       context 'volume creation option' do

--- a/spec/beaker/hypervisor/openstack_spec.rb
+++ b/spec/beaker/hypervisor/openstack_spec.rb
@@ -30,10 +30,14 @@ module Beaker
       it 'supports keystone v3 with implicit arguments' do
         v3_options = options
         v3_options[:openstack_auth_url] = 'https://example.com/identity/v3/auth'
+        v3_options[:openstack_project_name] = 'TeamTest_ab_c'
+        v3_options[:openstack_tenant] = nil
 
         credentials = Openstack.new(@hosts, v3_options).instance_eval('@credentials')
         expect(credentials[:openstack_user_domain]).to eq('Default')
         expect(credentials[:openstack_project_domain]).to eq('Default')
+        expect(credentials[:openstack_project_name]).to eq('TeamTest_ab_c')
+        expect(credentials[:openstack_tenant]).to be_nil
       end
 
       it 'supports keystone v3 with explicit arguments' do
@@ -41,10 +45,13 @@ module Beaker
         v3_options[:openstack_auth_url] = 'https://example.com/identity/v3/auth'
         v3_options[:openstack_user_domain] = 'acme.com'
         v3_options[:openstack_project_domain] = 'R&D'
+        v3_options[:openstack_project_name] = 'Team_test_abc'
+        v3_options[:openstack_tenant] = nil
 
         credentials = Openstack.new(@hosts, v3_options).instance_eval('@credentials')
         expect(credentials[:openstack_user_domain]).to eq('acme.com')
         expect(credentials[:openstack_project_domain]).to eq('R&D')
+        expect(credentials[:openstack_project_name]).to eq('Team_test_abc')
       end
     end
 


### PR DESCRIPTION
KeyStone V3 API needs the project name instead of the tenant's name
(such field doesn't exist anymore). Add proper parameter checks:
* With `v3`, `openstack_project_name` is expected
* With `v2`, `openstack_tenant` is expected (like before)

Also, in our environment no floating IP pools are available so I've also added an option which controls whether a floating IP should be allocated for the machines on which tests are ran.

Fix one issue with changed naming + bump `fog-openstack` requirement to `~> 1.0.0`.

Verification: spec and acceptance tests pass.