### PR TITLE
Add openstack_project_id logic etc, expand example nodeset in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,4 @@ bundle exec rake test:acceptance
 # Contributing
 
 Please refer to puppetlabs/beaker's [contributing](https://github.com/puppetlabs/beaker/blob/master/CONTRIBUTING.md) guide.
+

--- a/README.md
+++ b/README.md
@@ -157,4 +157,3 @@ bundle exec rake test:acceptance
 # Contributing
 
 Please refer to puppetlabs/beaker's [contributing](https://github.com/puppetlabs/beaker/blob/master/CONTRIBUTING.md) guide.
-

--- a/lib/beaker-openstack/version.rb
+++ b/lib/beaker-openstack/version.rb
@@ -1,3 +1,3 @@
 module BeakerOpenstack
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
Please note that this pull request :

adds the ability to define openstack_project_id, openstack_user_domain_id and openstack_project_domain_id parameters to expand features
AND in particular...

works around a long standing issue with the fog-openstack gem, where domain params are not processed correctly when passed as names, but are processed when declared as _id's.
Note that I have not expanded tests, and would appreciate assistance with that. I have however conducted manual verification that these changes work as desired against an OpenStack instance with and without domains enabled.