### PR TITLE
gemspec: remove allowed_push_host

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec
 
 group :release, optional: true do
   gem 'faraday-retry', '~> 2.1', require: false
-  gem 'github_changelog_generator','~> 1.16', '>= 1.16.4', require: false
+  gem 'github_changelog_generator', '>= 1.16.4', '< 2', require: false
 end

--- a/beaker-openstack.gemspec
+++ b/beaker-openstack.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.metadata = {
-    'allowed_push_host' => 'https://rubygems.org',
     'source_code_uri'   => 'https://github.com/voxpupuli/beaker-openstack',
     'changelog_uri'     => 'https://github.com/voxpupuli/beaker-openstack/blob/main/CHANGELOG.md',
     'bug_tracker_uri'   => 'https://github.com/voxpupuli/beaker-openstack/issues'


### PR DESCRIPTION
This only takes a single host:
https://guides.rubygems.org/publishing/

> RubyGems 2.2.0 and newer support the allowed_push_host metadata value to restrict gem pushes to a single host

But we are publishing to rubygems.org and github.com